### PR TITLE
Add Basic MasteryProgress Screen, Connect to Dev Backend

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>Flipt(Ed)</title>
+    <title>flipt.ED</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/App.js
+++ b/src/App.js
@@ -14,12 +14,13 @@ import QAScreen from './Components/TaskReview/QAScreen';
 import Task from './Components/Task';
 import MTaskOverview from './Components/MTaskOverview';
 import ProgressOverview from './Components/ProgressOverview';
+import MasteryProgress from './Components/MasteryProgress/MasteryProgress'
 import NavDrawer from './Components/NavDrawer';
 import { onError } from '@apollo/client/link/error';
 import "./App.css";
 
 const HOME_SCREEN_PATH = 'missions';
-const CURRENT_GRAPHQL_API_URI = process.env.REACT_APP_PROD_URI;
+const CURRENT_GRAPHQL_API_URI = process.env.REACT_APP_DEV_URI;
 
 //configures amplify to connect to our authentication server in AWS
 Amplify.configure({
@@ -191,6 +192,7 @@ function App() {
           <Route component = {Courses} exact path = '/courses'/>
           <Route component = {MissionsScreen} exact path = '/missions'/>
           <Route component = {ProgressOverview} exact path = '/progoverview'/>
+          <Route component = {MasteryProgress} exact path = '/mastery'/>
         </Switch>
         </div>
       </ApolloProvider>     

--- a/src/Components/MasteryProgress/MasteryIcon.js
+++ b/src/Components/MasteryProgress/MasteryIcon.js
@@ -1,0 +1,33 @@
+import { MASTERY_TAG } from './MasteryLabel';
+import FiberManualRecordIcon from '@material-ui/icons/FiberManualRecord';
+import StarIcon from '@material-ui/icons/Star';
+
+function MasteryIcon(props){
+
+  const mastery = props.mastery;
+
+  function getIconColor(){
+    if(mastery == MASTERY_TAG.NOT_GRADED) return '#E0E0E0';
+    if(mastery == MASTERY_TAG.NOT_MASTERED) return '#EA6868';
+    if(mastery == MASTERY_TAG.NEARLY_MASTERED) return '#F2C94C';
+    if(mastery == MASTERY_TAG.MASTERED) return '#30CC30';
+  }
+
+  function getIcon(){
+    if(mastery == MASTERY_TAG.MASTERED){
+      return (
+        <StarIcon style={{color: getIconColor()}}/>
+      );
+    } else {
+      return (
+        <FiberManualRecordIcon style={{color: getIconColor()}}/>
+      );
+    }
+  }
+
+  return (
+    <div>{getIcon()}</div>
+  );
+}
+
+export default MasteryIcon;

--- a/src/Components/MasteryProgress/MasteryLabel.js
+++ b/src/Components/MasteryProgress/MasteryLabel.js
@@ -1,0 +1,42 @@
+export const MASTERY_TAG = {
+  NOT_GRADED: "NOT_GRADED",
+  NOT_MASTERED: "NOT_MASTERED",
+  NEARLY_MASTERED: "NEARLY_MASTERED",
+  MASTERED: "MASTERED"
+}
+
+function MasteryLabel(props){
+
+  const mastery = props.mastery;
+
+  function getLabelColor(){
+    if(mastery == MASTERY_TAG.NOT_GRADED) return '#E0E0E0';
+    if(mastery == MASTERY_TAG.NOT_MASTERED) return '#EA6868';
+    if(mastery == MASTERY_TAG.NEARLY_MASTERED) return '#F2C94C';
+    if(mastery == MASTERY_TAG.MASTERED) return '#30CC30';
+  }
+
+  const labelStyle = {
+    backgroundColor: getLabelColor(),
+    borderRadius: "1em",
+    width: "max-content",
+    paddingLeft: "2em",
+    paddingRight: "2em",
+    fontFamily: "\"Poppins\", sans-serif",
+  };
+
+  function getLabelText(){
+    if(mastery == MASTERY_TAG.NOT_GRADED) return 'NOT GRADED';
+    if(mastery == MASTERY_TAG.NOT_MASTERED) return 'NOT MASTERED';
+    if(mastery == MASTERY_TAG.NEARLY_MASTERED) return 'NEARLY MASTERED';
+    if(mastery == MASTERY_TAG.MASTERED) return 'MASTERED';
+  }
+
+  return (
+    <div style={labelStyle}>
+      <h2>{getLabelText()}</h2>
+    </div>
+  );
+}
+
+export default MasteryLabel;

--- a/src/Components/MasteryProgress/MasteryProgress.css
+++ b/src/Components/MasteryProgress/MasteryProgress.css
@@ -1,0 +1,55 @@
+ul {
+  
+  justify-content: center;
+  align-items: center;
+}
+
+.card {
+  display: grid;
+  padding: 20px;
+  margin-top: 50px;
+  background-color: #CFDCFC;
+  box-shadow: 0 4px 8px 0 rgba(0,0,0,0.2);
+  transition: 0.3s;
+  width: 70%;
+  border-radius: 5px;
+  align-items: center;
+}
+
+.card h1 {
+  width: 100%;
+}
+
+.targetGrid {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  justify-items: center;
+  width: 100%;
+  grid-gap: 5em;
+}
+
+.gridContainer {
+  display: grid;
+  grid-template-columns: 1fr 4fr 1fr;
+  justify-items: center;
+  padding-top: 2em;
+}
+
+.detailsContainer {
+  display: flex;
+  flex-direction: column;
+}
+
+.detailsTableGrid {
+  display: grid;
+  grid-template-columns: 1fr 2fr 1fr;
+  justify-items: center;
+  padding-top: 2em;
+}
+
+.targetDetailsHeaderGrid{
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  justify-items: center;
+  padding-top: 2em;
+}

--- a/src/Components/MasteryProgress/MasteryProgress.js
+++ b/src/Components/MasteryProgress/MasteryProgress.js
@@ -1,0 +1,135 @@
+import { useQuery} from '@apollo/client';
+import React, { useState } from 'react';
+import ProgressBar from '../ProgressBar.js'
+import './MasteryProgress.css'
+import { GET_ALL_TARGET_PROGRESS, GET_TARGETS } from '../../gqlQueries.js';
+import { mockTargetProgress } from './MockData';
+import TargetDetails from './TargetDetails';
+import { makeStyles } from "@material-ui/core/styles";
+import Card from "@material-ui/core/Card";
+import CardActions from "@material-ui/core/CardActions";
+import CardContent from "@material-ui/core/CardContent";
+import Button from "@material-ui/core/Button";
+import Typography from "@material-ui/core/Typography";
+import MasteryLabel from './MasteryLabel';
+
+const useStyles = makeStyles({
+  root: {
+    minWidth: 275,
+    borderTop: "1em solid #4274F3"
+  },
+  bullet: {
+    display: "inline-block",
+    margin: "0 2px",
+    transform: "scale(0.8)"
+  },
+  title: {
+    fontSize: 14,
+    fontFamily: "\"Poppins\", sans-serif",
+  },
+  pos: {
+    marginBottom: 12
+  },
+  button: {
+    top: "auto",
+    width: "auto",
+    height: "auto",
+    fontFamily: "\"Poppins\", sans-serif",
+    color: "#4274F3",
+    textTransform: "none"
+  },
+  cardContent: {
+    paddingBottom: "0px",
+    fontFamily: "\"Poppins\", sans-serif",
+  },
+  targetName: {
+    paddingTop: "0.5em",
+    fontFamily: "\"Poppins\", sans-serif",
+  }
+});
+
+//This component is used to display the Student Progress Overview.
+function MasteryProgress() {
+
+const [focusedTarget, setFocusedTarget] = useState(null);
+
+//Query Target Progress Data
+const { loading, error, data, refetch: tpRefecth} = useQuery(GET_ALL_TARGET_PROGRESS, {
+  variables: {id: "Integrated Science"}
+});
+
+const classes = useStyles();
+
+//----------- Mastery Progress (Learning Targets)----------
+if(loading) return (
+  <h2>Loading...</h2>
+)
+
+if(error){
+  return (
+    <h2>Error!</h2>
+  );
+}
+
+console.log(data);
+
+const allTargetProgress = data.getAllTargetProgress;
+
+function changeFocusedTarget(target){
+  setFocusedTarget(target)
+}
+
+function mapTargetsToCards() {
+
+  return allTargetProgress.map((progress) => {
+    return (
+      <Card key={progress.target.targetId} className={classes.root}>
+      <CardContent className={classes.cardContent}>
+        <Typography
+          className={classes.title}
+          color="textSecondary"
+          gutterBottom
+        >
+          Learning Target
+        </Typography>
+        <Typography variant="h5" component="h2" className={classes.targetName}>
+        {progress.target.targetName}
+        </Typography>
+        <MasteryLabel mastery="NEARLY_MASTERED"/>
+      </CardContent>
+      <CardActions>
+        <Button className={classes.button} size="small" 
+          onClick={() => changeFocusedTarget(progress)}>Details</Button>
+      </CardActions>
+    </Card>
+    )        
+  });
+}
+
+function TargetGrid(){
+  return (
+    <div className="gridContainer">
+      <div/>
+      <div className="targetGrid">
+        {mapTargetsToCards()}
+      </div>
+      <div/>
+    </div>
+  );
+}
+
+function closeTargetDetails(){
+  setFocusedTarget(null);
+}
+
+return (
+    <div>
+        <h1>Mastery Progress</h1>
+        {focusedTarget != null ?
+          <TargetDetails closeCallback={closeTargetDetails} targetProgress={focusedTarget}/>
+          : <TargetGrid/>}                         
+    </div>
+  );
+}
+
+export default MasteryProgress;

--- a/src/Components/MasteryProgress/MockData.js
+++ b/src/Components/MasteryProgress/MockData.js
@@ -1,0 +1,411 @@
+export const mockTargetProgress = 
+{
+  "getAllTargetProgress": [
+
+    {
+      "target": {
+        "targetId": "TARGET_1231",
+        "targetName": "Learning Target 1.1",
+        "description": "This is a mock target.",
+        "subject": "Mockery",
+        "gradeLevel": 1,
+        "icon": "",
+        "standards": "",
+        "course": "Mocking 101"
+      },
+      "objectives": [
+        {
+          "objectiveId": "OBJECTIVE#123",
+          "objectiveName": "Backend-Mocked Objective 1",
+          "tasks": [
+            {
+              "mastery": "MASTERED",
+              "task": {
+                "id": "TASK#123",
+                "name": "Task 1",
+              }
+            },
+            {
+              "mastery": "NEARLY_MASTERED",
+              "task": {
+                "id": "TASK#123",
+                "name": "Task 1",
+              }
+            },
+            {
+              "mastery": "NOT_MASTERED",
+              "task": {
+                "id": "TASK#123",
+                "name": "Task 1",
+              }
+            },
+            {
+              "mastery": "NOT_GRADED",
+              "task": {
+                "id": "TASK#123",
+                "name": "Task 1",
+              }
+            },
+          ]
+        },
+        {
+          "objectiveId": "OBJECTIVE#1234",
+          "objectiveName": "Backend-Mocked Objective 2",
+          "tasks": [
+            {
+              "mastery": "MASTERED",
+              "task": {
+                "id": "TASK#123",
+                "name": "Task 1",
+              }
+            },
+            {
+              "mastery": "MASTERED",
+              "task": {
+                "id": "TASK#123",
+                "name": "Task 2",
+              }
+            },
+          ]
+        }
+      ],
+      "student": "MOCKUSER_123"
+    },
+
+    {
+      "target": {
+        "targetId": "TARGET_1232",
+        "targetName": "Learning Target 1.2",
+        "description": "This is a mock target.",
+        "subject": "Mockery",
+        "gradeLevel": 1,
+        "icon": "",
+        "standards": "",
+        "course": "Mocking 101"
+      },
+      "objectives": [
+        {
+          "objectiveId": "OBJECTIVE#123",
+          "objectiveName": "Backend-Mocked Objective 1",
+          "tasks": [
+            {
+              "mastery": "MASTERED",
+              "task": {
+                "id": "TASK#123",
+                "name": "Task 1",
+              }
+            },
+            {
+              "mastery": "NEARLY_MASTERED",
+              "task": {
+                "id": "TASK#123",
+                "name": "Task 1",
+              }
+            },
+            {
+              "mastery": "NOT_MASTERED",
+              "task": {
+                "id": "TASK#123",
+                "name": "Task 1",
+              }
+            },
+            {
+              "mastery": "NOT_GRADED",
+              "task": {
+                "id": "TASK#123",
+                "name": "Task 1",
+              }
+            },
+          ]
+        },
+        {
+          "objectiveId": "OBJECTIVE#1234",
+          "objectiveName": "Backend-Mocked Objective 2",
+          "tasks": [
+            {
+              "mastery": "MASTERED",
+              "task": {
+                "id": "TASK#123",
+                "name": "Task 1",
+              }
+            },
+            {
+              "mastery": "NEARLY_MASTERED",
+              "task": {
+                "id": "TASK#123",
+                "name": "Task 1",
+              }
+            },
+            {
+              "mastery": "NOT_MASTERED",
+              "task": {
+                "id": "TASK#123",
+                "name": "Task 1",
+              }
+            },
+            {
+              "mastery": "NOT_GRADED",
+              "task": {
+                "id": "TASK#123",
+                "name": "Task 1",
+              }
+            },
+          ]
+        }
+      ],
+      "student": "MOCKUSER_123"
+    },
+
+    {
+      "target": {
+        "targetId": "TARGET_1233",
+        "targetName": "Learning Target 1.3",
+        "description": "This is a mock target.",
+        "subject": "Mockery",
+        "gradeLevel": 1,
+        "icon": "",
+        "standards": "",
+        "course": "Mocking 101"
+      },
+      "objectives": [
+        {
+          "objectiveId": "OBJECTIVE#123",
+          "objectiveName": "Backend-Mocked Objective 1",
+          "tasks": [
+            {
+              "mastery": "MASTERED",
+              "task": {
+                "id": "TASK#123",
+                "name": "Task 1",
+              }
+            },
+            {
+              "mastery": "NEARLY_MASTERED",
+              "task": {
+                "id": "TASK#123",
+                "name": "Task 1",
+              }
+            },
+            {
+              "mastery": "NOT_MASTERED",
+              "task": {
+                "id": "TASK#123",
+                "name": "Task 1",
+              }
+            },
+            {
+              "mastery": "NOT_GRADED",
+              "task": {
+                "id": "TASK#123",
+                "name": "Task 1",
+              }
+            },
+          ]
+        },
+        {
+          "objectiveId": "OBJECTIVE#1234",
+          "objectiveName": "Backend-Mocked Objective 2",
+          "tasks": [
+            {
+              "mastery": "MASTERED",
+              "task": {
+                "id": "TASK#123",
+                "name": "Task 1",
+              }
+            },
+            {
+              "mastery": "NEARLY_MASTERED",
+              "task": {
+                "id": "TASK#123",
+                "name": "Task 1",
+              }
+            },
+            {
+              "mastery": "NOT_MASTERED",
+              "task": {
+                "id": "TASK#123",
+                "name": "Task 1",
+              }
+            },
+            {
+              "mastery": "NOT_GRADED",
+              "task": {
+                "id": "TASK#123",
+                "name": "Task 1",
+              }
+            },
+          ]
+        }
+      ],
+      "student": "MOCKUSER_123"
+    },
+
+    {
+      "target": {
+        "targetId": "TARGET_1234",
+        "targetName": "Learning Target 1.4",
+        "description": "This is a mock target.",
+        "subject": "Mockery",
+        "gradeLevel": 1,
+        "icon": "",
+        "standards": "",
+        "course": "Mocking 101"
+      },
+      "objectives": [
+        {
+          "objectiveId": "OBJECTIVE#123",
+          "objectiveName": "Backend-Mocked Objective 1",
+          "tasks": [
+            {
+              "mastery": "MASTERED",
+              "task": {
+                "id": "TASK#123",
+                "name": "Task 1",
+              }
+            },
+            {
+              "mastery": "NEARLY_MASTERED",
+              "task": {
+                "id": "TASK#123",
+                "name": "Task 1",
+              }
+            },
+            {
+              "mastery": "NOT_MASTERED",
+              "task": {
+                "id": "TASK#123",
+                "name": "Task 1",
+              }
+            },
+            {
+              "mastery": "NOT_GRADED",
+              "task": {
+                "id": "TASK#123",
+                "name": "Task 1",
+              }
+            },
+          ]
+        },
+        {
+          "objectiveId": "OBJECTIVE#1234",
+          "objectiveName": "Backend-Mocked Objective 2",
+          "tasks": [
+            {
+              "mastery": "MASTERED",
+              "task": {
+                "id": "TASK#123",
+                "name": "Task 1",
+              }
+            },
+            {
+              "mastery": "NEARLY_MASTERED",
+              "task": {
+                "id": "TASK#123",
+                "name": "Task 1",
+              }
+            },
+            {
+              "mastery": "NOT_MASTERED",
+              "task": {
+                "id": "TASK#123",
+                "name": "Task 1",
+              }
+            },
+            {
+              "mastery": "NOT_GRADED",
+              "task": {
+                "id": "TASK#123",
+                "name": "Task 1",
+              }
+            },
+          ]
+        }
+      ],
+      "student": "MOCKUSER_123"
+    },
+
+    {
+      "target": {
+        "targetId": "TARGET_1235",
+        "targetName": "Learning Target 1.5",
+        "description": "This is a mock target.",
+        "subject": "Mockery",
+        "gradeLevel": 1,
+        "icon": "",
+        "standards": "",
+        "course": "Mocking 101"
+      },
+      "objectives": [
+        {
+          "objectiveId": "OBJECTIVE#123",
+          "objectiveName": "Backend-Mocked Objective 1",
+          "tasks": [
+            {
+              "mastery": "MASTERED",
+              "task": {
+                "id": "TASK#123",
+                "name": "Task 1",
+              }
+            },
+            {
+              "mastery": "NEARLY_MASTERED",
+              "task": {
+                "id": "TASK#123",
+                "name": "Task 1",
+              }
+            },
+            {
+              "mastery": "NOT_MASTERED",
+              "task": {
+                "id": "TASK#123",
+                "name": "Task 1",
+              }
+            },
+            {
+              "mastery": "NOT_GRADED",
+              "task": {
+                "id": "TASK#123",
+                "name": "Task 1",
+              }
+            },
+          ]
+        },
+        {
+          "objectiveId": "OBJECTIVE#1234",
+          "objectiveName": "Backend-Mocked Objective 2",
+          "tasks": [
+            {
+              "mastery": "MASTERED",
+              "task": {
+                "id": "TASK#123",
+                "name": "Task 1",
+              }
+            },
+            {
+              "mastery": "NEARLY_MASTERED",
+              "task": {
+                "id": "TASK#123",
+                "name": "Task 1",
+              }
+            },
+            {
+              "mastery": "NOT_MASTERED",
+              "task": {
+                "id": "TASK#123",
+                "name": "Task 1",
+              }
+            },
+            {
+              "mastery": "NOT_GRADED",
+              "task": {
+                "id": "TASK#123",
+                "name": "Task 1",
+              }
+            },
+          ]
+        }
+      ],
+      "student": "MOCKUSER_123"
+    }
+  ]
+};

--- a/src/Components/MasteryProgress/TargetDetails.js
+++ b/src/Components/MasteryProgress/TargetDetails.js
@@ -1,0 +1,133 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { makeStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
+import Collapse from '@material-ui/core/Collapse';
+import IconButton from '@material-ui/core/IconButton';
+import Table from '@material-ui/core/Table';
+import TableBody from '@material-ui/core/TableBody';
+import TableCell from '@material-ui/core/TableCell';
+import TableContainer from '@material-ui/core/TableContainer';
+import TableHead from '@material-ui/core/TableHead';
+import TableRow from '@material-ui/core/TableRow';
+import Typography from '@material-ui/core/Typography';
+import Paper from '@material-ui/core/Paper';
+import KeyboardArrowDownIcon from '@material-ui/icons/KeyboardArrowDown';
+import KeyboardArrowUpIcon from '@material-ui/icons/KeyboardArrowUp';
+import PREV from '../Images/previous.svg';
+import MasteryLabel from './MasteryLabel';
+import MasteryIcon from './MasteryIcon';
+
+const useRowStyles = makeStyles({
+  root: {
+    '& > *': {
+      borderBottom: 'unset',
+    },  
+  },
+  objectiveName: {
+    fontFamily: "\"Poppins\", sans-serif",
+    fontSize: "20px"
+  },
+  subTitle: {
+    fontFamily: "\"Poppins\", sans-serif",
+    fontSize: "16px"
+  },
+});
+
+function Row(props) {
+  const { row } = props;
+  const [open, setOpen] = React.useState(false);
+  const classes = useRowStyles();
+
+  return (
+    <React.Fragment>
+      <TableRow className={classes.root}>
+        <TableCell>
+          <IconButton aria-label="expand row" size="small" onClick={() => setOpen(!open)}>
+            {open ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
+          </IconButton>
+        </TableCell>
+        <TableCell component="th" scope="row" className={classes.objectiveName}>
+          {"Objective " + row.objectiveName}
+        </TableCell>
+        <TableCell align="left">
+        <MasteryIcon mastery={"NEARLY_MASTERED"}/>
+        </TableCell>
+      </TableRow>
+      <TableRow>
+        <TableCell style={{ paddingBottom: 0, paddingTop: 0 }} colSpan={6}>
+          <Collapse in={open} timeout="auto" unmountOnExit>
+            <Box margin={1}>
+              <Table size="small" aria-label="purchases">
+                <TableBody>
+                  {row.tasks.map((taskMastery, index) => (
+                    <TableRow key={index}>
+                      <TableCell align="left" component="th" scope="row">
+                        {"Task " + taskMastery.task.name}
+                      </TableCell>
+                      <TableCell align="left">
+                        <MasteryLabel mastery={taskMastery.mastery}/>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </Box>
+          </Collapse>
+        </TableCell>
+      </TableRow>
+    </React.Fragment>
+  );
+}
+
+const useTableStyles = makeStyles({
+  root: {
+    textAlign: "left"
+  },
+  columnTitle: {
+    fontFamily: "\"Poppins\", sans-serif",
+    fontSize: "20px",
+    textAlign: "left",
+    color: "#828282"
+  },
+});
+
+function TargetDetails(props){
+
+  const targetProgress = props.targetProgress;
+  const classes = useTableStyles();
+
+  return (
+    <div className="detailsContainer">
+      <div className="targetDetailsHeaderGrid">
+        <div onClick={() => props.closeCallback()}>
+          <img src={PREV} alt="Previous Button"/>    
+        </div>
+        <h1>{"Learning Target: " + targetProgress.target.targetName}</h1>
+        <div/>
+      </div>
+      <div className="detailsTableGrid">
+        <div/>
+        <TableContainer component={Paper}>
+          <Table aria-label="collapsible table">
+            <TableHead>
+              <TableRow>
+                <TableCell />
+                <TableCell align="left"><h2 className={classes.columnTitle}>Target Item</h2></TableCell>
+                <TableCell align="left"><h2 className={classes.columnTitle}>Mastery</h2></TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {targetProgress.objectives.map((row) => (
+                <Row key={row.name} row={row} />
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+        <div/>
+      </div>
+    </div>
+  );
+}
+
+export default TargetDetails;

--- a/src/Components/Mission.js
+++ b/src/Components/Mission.js
@@ -5,9 +5,12 @@ import MTaskOverview from './MTaskOverview.js';
 import './Mission.css';
 
 //This component is used to display the mission page.
-function Mission() {
+function Mission(props) {
+
+  const missionId = props?.location?.state?.id;
+
   const { loading, error, data} = useQuery(GET_MISSION, {
-    variables: { id: "da0719ba103" },
+    variables: { id: missionId },
   });
 
   const [focusedTask, setFocusedTask] = useState(null);

--- a/src/Components/MissionsScreen.js
+++ b/src/Components/MissionsScreen.js
@@ -20,7 +20,7 @@ export default function MissionsScreen() {
     });
 
     const { loading: progressLoading, error: progressError, data: progressData, refetch : progressRefetch} = useQuery(GET_ALL_MISSION_PROGRESS, {
-      variables: { id: " " },
+      variables: { id: "Integrated Science" },
     });
 
     if(loading || progressLoading) return (
@@ -58,7 +58,7 @@ export function MissionsScreenDisplay(data, progressData, hist, focusedMission, 
   function MissionOverview(props) {
 
     if (props.mission != null){
-      var prog = calculateMissionProgress("MISSION#123", progressData);
+      var prog = calculateMissionProgress(props.mission.id, progressData);
       return (
         <div data-testid="missionOverview">
           <h1>{props.mission.name}</h1>
@@ -75,7 +75,7 @@ export function MissionsScreenDisplay(data, progressData, hist, focusedMission, 
               done={prog}
             />
           </div>
-          <h1 style={{"font-size": "18px", margin: "0", padding: "0", align: "center", "padding-bottom": "20px"}}>{prog}% Complete</h1>
+          <h1 style={{"font-size": "18px", margin: "0", padding: "0", align: "center", "padding-bottom": "20px"}}>{Math.round(prog)}% Complete</h1>
           </div>
           <div className="start">
             <button data-testid="redirectToMissionButton" style={{top: "0"}}onClick={()=>redirectToMission(hist, props.mission.id)}>Continue</button>

--- a/src/gqlQueries.js
+++ b/src/gqlQueries.js
@@ -340,9 +340,11 @@ export const GET_ALL_TARGET_PROGRESS = gql `
         objectiveId
       	objectiveName
         tasks {
-          taskId
-          taskName
           mastery
+          task {
+            id
+            name
+          }
         }
       }
       student


### PR DESCRIPTION
This PR adds a first version of the mastery progress screen, which exists at the route `/mastery`. This screen is not finished but is functional as it is. It will likely be updated.

The PR also connects our app to the backend Dev API instead of the Prod API.  This will allow us to develop against the new APIs that were recently added to the backend, many of which we need.

After merging this PR, everyone will have to update their .env file.   Ask me and I'll send you the updated .env file content.